### PR TITLE
fix(checkedin): add extra resiliency if desk is already checked in

### DIFF
--- a/robot/reservations.py
+++ b/robot/reservations.py
@@ -5,6 +5,10 @@ from typing import List
 from robot.user import UserInfo
 
 
+class AlreadyCheckedInError(Exception):
+    pass
+
+
 class Reservation:
 
     LIST_RESERVATIONS_URL_TEMPLATE = "https://api.robinpowered.com/v1.0/reservations/seats?before={}&after={}&seat_ids={}"
@@ -71,7 +75,7 @@ class Reservation:
             raise Exception("should only contain 1 reservation")
         reservation = reservations[0]
         if reservation['confirmation'] is not None:
-            return Exception("already checked in")
+            raise AlreadyCheckedInError("desk is already checked in")
         return reservation['id']
 
     def _reserve(self) -> str:

--- a/robot/robin.py
+++ b/robot/robin.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 from typing import Dict, List
 
-from robot.reservations import Reservation
+from robot.reservations import AlreadyCheckedInError, Reservation
 
 
 class Robin:
@@ -41,15 +41,19 @@ class Robin:
     def check_in(self, current: datetime) -> Dict:
         results = {}
         for user_info in self.users_info:
-            _, reserver_id = user_info.seat_id, user_info.reserver_id
-            reservation = Reservation(user_info, current)
-            reservation_id = reservation._get_id()
-            if "-1" == reservation_id:
-                print(f"no reservation to confirm for {reserver_id}")
-                continue
+            try:
+                _, reserver_id = user_info.seat_id, user_info.reserver_id
+                reservation = Reservation(user_info, current)
+                reservation_id = reservation._get_id()
+                if "-1" == reservation_id:
+                    print(f"no reservation to confirm for {reserver_id}")
+                    continue
 
-            reservation._check_in(reservation_id)
-            print(f"check in successful for {reservation_id}")
-            results[reserver_id] = True
-
+                reservation._check_in(reservation_id)
+                print(f"check in successful for {reservation_id}")
+                results[reserver_id] = True
+            except AlreadyCheckedInError as e:
+                print(f"error whilst checking in: {e}")                
+                results[reserver_id] = False
+                pass
         return results

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name='robin-powered-bot',
-    version='0.0.5',
+    version='0.0.6',
     description='Provides a set of utilities to simplify communication with robin-powered API and more easily automate bookings.',
     url='https://github.com/donatobarone/robin-powered-bot',
     author='Donato Barone',

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -84,6 +84,58 @@ JSON_RESPONSE = {
     }
 }
 
+RESERVATION_CHECKED_IN_BODY = {
+    "meta": {
+        "status_code": 200,
+        "status": "OK",
+        "message": "",
+        "more_info": {},
+        "errors": []
+    },
+    "data": [{
+        "id": "2498667793369531480",
+        "group_seat_reservation_id": None,
+        "seat_id": 196962,
+        "reserver_id": 619521,
+        "type": "hoteled",
+        "title": None,
+        "start": {
+            "date_time": "2022-08-22T11:00:00+0100",
+            "time_zone": "Etc/UTC"
+        },
+        "end": {
+            "date_time": "2022-08-22T19:00:00+0100",
+            "time_zone": "Etc/UTC"
+        },
+        "recurrence": None,
+        "series_id": None,
+        "recurrence_id": None,
+        "created_at": "2023-07-22T12:06:52+0000",
+        "updated_at": "2023-08-04T13:00:49+0000",
+        "reservee": {
+            "email": "dbarone@factset.com",
+            "user_id": 619521,
+            "visitor_id": None,
+            "participation_status": "accepted"
+        },
+        "confirmation": {
+            "seat_reservation_id": "2498667793369531480",
+            "device_id": None,
+            "user_id": 619521,
+            "confirmed_at": {
+                "date": "2023-08-04 13:00:49.000000",
+                "timezone_type": 3,
+                "timezone": "UTC"
+            }
+        }
+    }],
+    "paging": {
+        "page": 1,
+        "per_page": 10,
+        "has_next_page": False
+    }
+}
+
 EMPTY_JSON_RESPONSE = {
     "meta": {
         "status_code": 200,
@@ -115,6 +167,8 @@ RESERVATION_BODY = {
     },
     "reserver_id": 619521
 }
+
+
 
 SUCCESSFUL_RESERVATION = {
     "meta": {
@@ -248,3 +302,4 @@ SUCCESSFUL_CHECK_IN = {
         }
     }
 }
+

--- a/tests/robin_test.py
+++ b/tests/robin_test.py
@@ -7,7 +7,7 @@ from robot.robin import Robin
 from robot.user import UserInfo
 from tests.constants import (DURATION, EMPTY_JSON_RESPONSE, JSON_RESPONSE,
                              START_TIME, SUCCESSFUL_CHECK_IN,
-                             SUCCESSFUL_RESERVATION)
+                             SUCCESSFUL_RESERVATION, RESERVATION_CHECKED_IN_BODY)
 
 
 @pook.on
@@ -45,3 +45,14 @@ def test_checkin_reservation():
              response_json=SUCCESSFUL_CHECK_IN)
     results = r.check_in(datetime(2022, 9, 22))
     assert results == {1: True}
+
+
+@pook.on
+def test_already_checkedin_reservation():
+
+    users_info = [UserInfo("dbarone@factset.com", START_TIME, DURATION, 111, 1, "Etc/UTC")]
+    r = Robin(users_info)
+    pook.get(Reservation.build_list_reservations_url(datetime(2022, 9, 22, 11), datetime(2022, 9, 22, 19), 111),
+             reply=200, response_json=RESERVATION_CHECKED_IN_BODY)
+    results = r.check_in(datetime(2022, 9, 22))
+    assert results == {1: False}


### PR DESCRIPTION
## Summary

I have seen a few scenarios where the library would throw and exception and stop processing the other users just because 1 was already checked in, so this change will increase resiliency by ignoring the seats that are already checked in. 
