### PR TITLE
fix: add try/except during reservation

### DIFF
--- a/robot/robin.py
+++ b/robot/robin.py
@@ -19,23 +19,27 @@ class Robin:
             seat_id, reserver_id = user_info.seat_id, user_info.reserver_id
             results[reserver_id] = {}
             for current in self.daterange(start, end):
-                if current.weekday() > 4:
-                    print(f"skip weekends {current.strftime('%Y-%m-%d')}")
-                    continue
+                try:
+                    if current.weekday() > 4:
+                        print(f"skip weekends {current.strftime('%Y-%m-%d')}")
+                        continue
 
-                print(
-                    f"make a reservation seat_id: {seat_id} date: {current.strftime(f'%Y-%m-%d')}")
-                reservation = Reservation(user_info, current)
-                if "-1" != reservation._get_id():
-                    continue
+                    print(
+                        f"make a reservation seat_id: {seat_id} date: {current.strftime(f'%Y-%m-%d')}")
+                    reservation = Reservation(user_info, current)
+                    if "-1" != reservation._get_id():
+                        continue
 
-                reservation_id = reservation._reserve()
-                if "-1" == reservation_id:
-                    print(f"reservation {reservation_id} too far in the future. stop going through dates")
-                    break
-                print(f"reservation successful with id {reservation_id}")
-                results[reserver_id][current.strftime("%Y-%m-%d")] = True
-
+                    reservation_id = reservation._reserve()
+                    if "-1" == reservation_id:
+                        print(f"reservation {reservation_id} too far in the future. stop going through dates")
+                        break
+                    print(f"reservation successful with id {reservation_id}")
+                    results[reserver_id][current.strftime("%Y-%m-%d")] = True
+                except AlreadyCheckedInError as e:
+                    print(f"error whilst reserving desk in: {e}")
+                    results[reserver_id][current.strftime("%Y-%m-%d")] = False
+                    pass
         return results
 
     def check_in(self, current: datetime) -> Dict:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name='robin-powered-bot',
-    version='0.0.6',
+    version='0.0.7',
     description='Provides a set of utilities to simplify communication with robin-powered API and more easily automate bookings.',
     url='https://github.com/donatobarone/robin-powered-bot',
     author='Donato Barone',


### PR DESCRIPTION
## Summary

During reservation, similar to what used to happen during check-in, some desks will be already checked in and that will generate an exception, so just skipping those cases altogether for now. 